### PR TITLE
Clarified 'Introduction to Indicator' header

### DIFF
--- a/.github/ISSUE_TEMPLATE/catalog_submission.yml
+++ b/.github/ISSUE_TEMPLATE/catalog_submission.yml
@@ -43,7 +43,7 @@ body:
   - type: textarea
     id: indicator_intro
     attributes:
-      label: Introduction to Indicator
+      label: Introduction to Indicator (i.e. "What is this?")
       description: Please introduce the indicator within an appropriate context.
       value: "Proceed as though this were a short summary of a typical introduction section in a paper."
     validations:


### PR DESCRIPTION
Added text to clarify that the 'Introduction to Indicator' field goes in the "What is this?" section of the catalog page.