### PR TITLE
Fix/i189 GitHub api issues

### DIFF
--- a/R/build_rmd_from_issue.R
+++ b/R/build_rmd_from_issue.R
@@ -1,14 +1,14 @@
 #' Reads in issues from GitHub and create rmds
-#' 
+#'
 #' Some of the GitHub issues in catalog are tagged as "submission".
 #' These issues are filtered and parsed then used to build catalog rmds.
 #' Each rmd will represent a catalog index
-#' 
+#'
 #' @param pullAllIssues Boolean. Should all issues be pulled from Github (Default = F). When TRUE the pull is saved locally
 #' @param pullSingleIssue Boolean. should a single issue be pulled from Github (Default = F)
-#' @param issueNum numeric. The GitHub issue number to be parsed  (Default = 1). If issueNum = NULL then 
-#' ALL issues will be processed from a previous pull using (pullAllIssues = T) 
-#' 
+#' @param issueNum numeric. The GitHub issue number to be parsed  (Default = 1). If issueNum = NULL then
+#' ALL issues will be processed from a previous pull using (pullAllIssues = T)
+#'
 #' @return list
 #' \item{listobject}{list formatted in a way to pass to make_rmd function. Mainly used for debugging}
 
@@ -21,49 +21,47 @@ source(here::here("R/pull_single_issue.R"))
 library(ecodata)
 
 
-build_rmd_from_issue <- function(pullAllIssues=F,pullSingleIssue= F,issueNum = 1) {
-
-  if (pullAllIssues){ 
+build_rmd_from_issue <- function(
+  pullAllIssues = FALSE,
+  pullSingleIssue = FALSE,
+  issueNum = 1
+) {
+  if (pullAllIssues) {
     # this will pull all issues from GitHub API
     issueData <- pull_all_issues()
   } else {
-    if(pullSingleIssue) {
+    if (pullSingleIssue) {
       # pull single issue from GitHub
       issueData <- pull_single_issue(issueNum)
     } else {
       # read in previously pulled set of GitHub Issues
       issueData <- readRDS(here::here("data-raw/submissionIssueNumbers.rds"))
-      if(is.null(issueNum)) {
+      if (is.null(issueNum)) {
         # Process  all
       } else {
         # Process single issue
         issueData$submissions <- issueNum
       }
-        
     }
   }
-  
+
   # select all submission issues
   submissions <- issueData$submissions
-  
 
   # Process the issues to create an rmd for bookdown
   for (issuenum in submissions) {
-    message(paste0("Issue number: ",issuenum))
-    ### Parse issue 
-    parsedIssue <- parse_issue(issueData,issuenum)
-    
+    message(paste0("Issue number: ", issuenum))
+    ### Parse issue
+    parsedIssue <- parse_issue(issueData, issuenum)
+
     # create list of parsed issue values
     listobject <- create_listobject(parsedIssue)
-    message(paste0("making ... chapters/",listobject$indicatorname,".rmd"))
+    message(paste0("making ... chapters/", listobject$indicatorname, ".rmd"))
     ### make an rmd from content
     make_rmd(listobject)
-    
   }
-  
+
   message("Look in the 'chapters' folder to see the rmds")
-  
+
   return(invisible(listobject))
-
 }
-

--- a/R/pull_all_issues.r
+++ b/R/pull_all_issues.r
@@ -1,7 +1,7 @@
 #' Pulls all issues from GitHub API
 #'
 #' Issues that we are interested in have a "submission" tag associated with them.
-#' This submission tag is assigned in GitHub to the the issue Template 
+#' This submission tag is assigned in GitHub to the the issue Template
 #' so when a submission is entered it is automatically tagged
 #'
 #'
@@ -9,24 +9,47 @@
 #' \item{issueData}{a list of all issues . Each element is an issue}
 #' \item{submissions}{the issue numbers that are "submissions"}
 
-
-
 pull_all_issues <- function() {
   # Define repo information, pull issues from GH API and subset 'submissions'
   repo <- 'https://api.github.com/repos/NOAA-EDAB/catalog/issues'
   # pull all issues and select all submission issues
   issueData <- list()
+  issueList <- list()
+  issues <- NULL
+  submissions <- NULL
+  pulling <- TRUE
+  page <- 1
   # pulls 100 issues
-  repopull <- paste0(repo,"?per_page=200")
-  issues <- jsonlite::fromJSON(repopull)
-  # make sure it has the "submission" tag associated with it
-  indices <- which(unlist(lapply(issues$labels,function(x) {if(length(x$name)==0){F}else{x$name=="submission"}})))
-  submissions <- issues$number[indices]
+  while (pulling) {
+    request_url <- paste0(repo, "?per_page=100&page=", page)
+    # pull the data
+    current_batch <- jsonlite::fromJSON(request_url)
+    # Check if we got data back
+    if (length(current_batch) == 0) {
+      pulling <- FALSE
+    } else {
+      # make sure it has the "submission" tag associated with it
+      indices <- which(unlist(lapply(current_batch$labels, function(x) {
+        if (length(x$name) == 0) {
+          F
+        } else {
+          x$name == "submission"
+        }
+      })))
+      subs <- current_batch$number[indices]
+      # store
+      issues <- dplyr::bind_rows(issues, current_batch)
+      issueList[[page]] <- current_batch
+
+      submissions <- c(submissions, subs)
+      page <- page + 1
+    }
+  }
+  #issues <- do.call(dplyr::bind_rows, issueList)
   # save pull to rds for debugging
   issueData$issues <- issues
   issueData$submissions <- submissions
-  saveRDS(issueData,here::here("data-raw/submissionIssueNumbers.rds"))
-  
+  saveRDS(issueData, here::here("data-raw/submissionIssueNumbers.rds"))
+
   return(issueData)
-  
 }

--- a/R/pull_all_issues.r
+++ b/R/pull_all_issues.r
@@ -28,7 +28,8 @@ pull_all_issues <- function() {
     if (length(current_batch) == 0) {
       pulling <- FALSE
     } else {
-      # Filter out anything that has a 'pull_request' element
+      # Filter out anything that has a 'pull_request' element.
+      # Github treat PRs as issues too!
       if ("pull_request" %in% names(current_batch)) {
         pure_issues_ind <- is.na(current_batch$pull_request$url)
         pure_issues <- current_batch[pure_issues_ind, ]
@@ -38,11 +39,10 @@ pull_all_issues <- function() {
         pure_issues <- current_batch
       }
 
-      print(dim(pure_issues))
       # make sure it has the "submission" tag associated with it
       indices <- which(unlist(lapply(pure_issues$labels, function(x) {
         if (length(x$name) == 0) {
-          F
+          FALSE
         } else {
           x$name == "submission"
         }

--- a/R/pull_all_issues.r
+++ b/R/pull_all_issues.r
@@ -28,18 +28,29 @@ pull_all_issues <- function() {
     if (length(current_batch) == 0) {
       pulling <- FALSE
     } else {
+      # Filter out anything that has a 'pull_request' element
+      if ("pull_request" %in% names(current_batch)) {
+        pure_issues_ind <- is.na(current_batch$pull_request$url)
+        pure_issues <- current_batch[pure_issues_ind, ]
+        pure_issues <- pure_issues |>
+          dplyr::select(-pull_request, -draft)
+      } else {
+        pure_issues <- current_batch
+      }
+
+      print(dim(pure_issues))
       # make sure it has the "submission" tag associated with it
-      indices <- which(unlist(lapply(current_batch$labels, function(x) {
+      indices <- which(unlist(lapply(pure_issues$labels, function(x) {
         if (length(x$name) == 0) {
           F
         } else {
           x$name == "submission"
         }
       })))
-      subs <- current_batch$number[indices]
+      subs <- pure_issues$number[indices]
       # store
-      issues <- dplyr::bind_rows(issues, current_batch)
-      issueList[[page]] <- current_batch
+      issues <- dplyr::bind_rows(issues, pure_issues)
+      #issueList[[page]] <- pure_issues
 
       submissions <- c(submissions, subs)
       page <- page + 1


### PR DESCRIPTION
## Reason

When requesting all issues from GitHub API, GitHub will return at a maximum 100. So you need to iterate over the pages of issues to pull everything. At present we have 108 issues - 2 pages. This PR addresses this

## To review

source and run the `pull_all_issues` function