### PR TITLE
Update: Create placeholder dissolved oxygen page and add to book

### DIFF
--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -80,6 +80,7 @@ rmd_files:
     -   "chapters/cold_spell.rmd"
     -   "chapters/timing_shifts.rmd"
     -   "chapters/MOM6_forecasts.rmd"
+    -   "chapters/dissolved_oxygen.rmd"
     -   "chapters/ocean_acidification.rmd"
     -   "chapters/gom_acidification.rmd"
 #

--- a/chapters/dissolved_oxygen.rmd
+++ b/chapters/dissolved_oxygen.rmd
@@ -1,0 +1,81 @@
+# Dissolved Oxygen {#dissolved_oxygen}
+
+**Description**: Coming soon
+
+**Indicator family**: 
+
+
+
+
+**Contributor(s)**: Coming soon
+
+**Affiliations**: Coming soon
+
+```{r echo=FALSE}
+knitr::opts_chunk$set(echo = F)
+library(ecodata)
+```
+## Introduction to Indicator
+Coming soon
+
+## Key Results and Visualizations
+Coming soon
+
+```{r plot_dissolved_oxygen}
+# Plot indicator
+ggplotObject <- ecodata::plot_dissolved_oxygen()
+ggplotObject
+```
+
+
+## Indicator statistics 
+Spatial scale: Coming soon
+
+Temporal scale: Coming soon
+
+**Synthesis Theme**:
+
+
+
+
+```{r autostats_dissolved_oxygen}
+# Either from Contributor or ecodata
+```
+
+## Implications
+Coming soon
+
+## Get the data
+
+**Point of contact**: [Coming soon](mailto:Coming soon){.email}
+
+**ecodata name**: `ecodata::dissolved_oxygen`
+
+**Variable definitions**
+
+Coming soon
+
+```{r vars_dissolved_oxygen}
+# Pull all var names
+vars <- ecodata::dissolved_oxygen |>
+   dplyr::select(Var) |>
+   dplyr::distinct()
+
+DT::datatable(vars)
+```
+**Indicator Category**:
+
+
+
+
+## Public Availability
+
+Source data are publicly available.
+
+## Accessibility and Constraints
+
+_No response_
+
+**tech-doc link**
+<https://noaa-edab.github.io/tech-doc/dissolved_oxygen.html>
+


### PR DESCRIPTION
### Justification
Links to a dissolved oxygen page, which does not exist, were included in the SOE reports. I have added an empty catalog page at this URL to prevent these links from directing to the 404 page at the request of the SOE editors.

### Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply) 

### Reviewer instructions:
Please test by:
1) Building/loading _ecodata_ from the `pre-production` branch
2) Rendering catalog from the `update/dissolved-oxy-placeholder` branch using: `bookdown::render_book()`*
3) Briefly reviewing the new page in the book (found in "_book\index.html") for issues**
4) Briefly reviewing changed files for issues**

*I strongly recommend replacing all instances of `n = 10` to `n = 0`. Rendering the book with short term trends disabled saves considerable time.

**Please review "Dissolved Oxygen" (pg 66). These reviews can be a very brief scan of this page for any obvious issues.