### PR TITLE
Fix: Rewrite checkbox string extraction to be case insensitive

### DIFF
--- a/R/create_listobject.R
+++ b/R/create_listobject.R
@@ -1,26 +1,28 @@
 #' Reads in issues from GitHub and create rmds
-#' 
+#'
 #' Some of the GitHub issues in catalog are tagged as "submission".
 #' These issues are filtered and parsed then used to build catalog rmds.
 #' Each rmd will represent a catalog index
-#' 
+#'
 #' @param issuenum value. manually entered to select issue for parsing  (Default = NULL, all issues will be parsed)
-#' 
-#' @return 
+#'
+#' @return
 
 create_listobject <- function(parsedIssue) {
-    
   ### Generate listobject using gh_parser
   listobject <- list()
   listobject$dataname <- parsedIssue$`### Data Name (This will be the displayed title in Catalog)`
   listobject$indicatorname <- parsedIssue$`### Indicator Name (as exists in ecodata)`
   listobject$description <- parsedIssue$`### Data Description`
-  
-  ## Parse checkboxes 
+
+  ## Parse checkboxes
   family <- parsedIssue$`### Family (Which group is this indicator associated with?)`
-  members <- unlist(stringr::str_extract_all(family,"- \\[X\\]\\s+[a-zA-z ,]+"))
-  members <- paste0(members,"\r\n",collapse="")
-  
+  members <- unlist(stringr::str_extract_all(
+    family,
+    stringr::regex("- \\[X\\]\\s+[a-zA-z ,]+", ignore_case = T)
+  ))
+  members <- paste0(members, "\r\n", collapse = "")
+
   listobject$family <- members
   listobject$contributors <- parsedIssue$`### Data Contributors`
   listobject$affiliations <- parsedIssue$`### Affiliation`
@@ -28,24 +30,28 @@ create_listobject <- function(parsedIssue) {
   listobject$visualizations <- parsedIssue$`### Key Results and Visualization`
   listobject$indicatorStatsSpatial <- parsedIssue$`### Spatial Scale`
   listobject$indicatorStatsTemporal <- parsedIssue$`### Temporal Scale`
-  
-  ## Parse checkboxes 
-  synthesis <-  parsedIssue$`### Synthesis Theme`
-  members <- unlist(stringr::str_extract_all(synthesis,"- \\[X\\]\\s+[a-zA-z ,]+"))
-  members <- paste0(members,"\r\n",collapse="")
-  
+
+  ## Parse checkboxes
+  synthesis <- parsedIssue$`### Synthesis Theme`
+  members <- unlist(stringr::str_extract_all(
+    synthesis,
+    stringr::regex("- \\[X\\]\\s+[a-zA-z ,]+", ignore_case = T)
+  ))
+  members <- paste0(members, "\r\n", collapse = "")
+
   listobject$synthesisTheme <- members
   listobject$implications <- parsedIssue$`### Implications`
   listobject$poc <- parsedIssue$`### Point(s) of Contact`
   listobject$defineVariables <- parsedIssue$`### Define Variables`
-  
-  
-  ## Parse checkboxes 
-  indicator <-  parsedIssue$`### Indicator Category`
-  members <- unlist(stringr::str_extract_all(indicator,"- \\[X\\]\\s+[a-zA-z ,]+"))
-  members <- paste0(members,"\r\n",collapse="")
-  
-  
+
+  ## Parse checkboxes
+  indicator <- parsedIssue$`### Indicator Category`
+  members <- unlist(stringr::str_extract_all(
+    indicator,
+    stringr::regex("- \\[X\\]\\s+[a-zA-z ,]+", ignore_case = T)
+  ))
+  members <- paste0(members, "\r\n", collapse = "")
+
   listobject$indicatoryCategory <- members
   listobject$other <- parsedIssue$`### If other, please specify indicator category`
 
@@ -53,8 +59,6 @@ create_listobject <- function(parsedIssue) {
   listobject$accessibility <- parsedIssue$`### Accessibility and Constraints`
   listobject$primaryContact <- parsedIssue$`### Primary Contact`
   listobject$secondaryContact <- parsedIssue$`### Secondary Contact`
-  
-  
-  return(listobject)
 
+  return(listobject)
 }


### PR DESCRIPTION
### Justification
Github changed its internal markdown language such that checked boxes now appear as a lowercase `[x]` instead of a capital `[X]`. This broke the parsing of checkboxes in issues when building pages. I've used the `stringr::regex` wrapper function with the argument `ignore_case = T` to make the parsing case insensitive. This wrapper tells other `stringr` functions how to treat the pattern argument. In this case, it gives the instruction to treat the pattern as a case insensitive regular expression. The expression we match could change (there is now redundant case insensitivity) but this is a quicker patch for now.

### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

### Reviewer instructions:
Quick review for proper structure and syntax. There are no changes to pages present here, just the underlying code. All pages will be rebuilt in a subsequent pull request, which will include this fix and the implementation most of the EDAB review feedback. A full rebuild of the book is beyond the scope of this patch.