### PR TITLE
Feature(#215): Redeploy revised pages

### DIFF
--- a/chapters/MOM6_forecasts.rmd
+++ b/chapters/MOM6_forecasts.rmd
@@ -1,35 +1,41 @@
 # MOM6 Forecasts {#MOM6_forecasts}
 
-**Description**: Coming soon
+**Description**: Seasonal and decadal bottom temperature predictions for the Northeast US shelf.
 
 **Indicator family**: 
 
 - [x] Oceanographic
 
 
-**Contributor(s)**: Coming soon
+**Contributor(s)**: Andrew Ross
 
-**Affiliations**: NEFSC
+**Affiliations**: OAR/GFDL
 
 ```{r echo=FALSE}
 knitr::opts_chunk$set(echo = F)
 library(ecodata)
 ```
 ## Introduction to Indicator
-Coming soon
+This indicator consists of predictions of bottom temperature from a high-resolution regional ocean model, MOM6-NWA12, that is regularly run at NOAA GFDL to produce seasonal (next year) and decadal (next ten years) forecasts for the Northwest Atlantic Ocean. Both predictions are created by forcing the regional ocean model with boundary conditions from GFDL's Seamless System for Prediction and EArth System Research (SPEAR), a global model. This "downscaling" of SPEAR with MOM6-NWA12 results in high-resolution forecasts that resolve many of the important details of the Northeast US region. 10 ensemble members are downscaled for each forecast to produce better predictions and an estimate of uncertainty. 
+
+The seasonal prediction maps show whether bottom temperature is most likely to be cooler than average, near average, or warmer than average, or if no category is particularly likely. These averages are based on historical bottom temperatures during 1994--2023. The categories are defined as terciles of the historical conditions: cooler than average conditions are in the lowest 1/3 of historical values, near average are in the middle 1/3, and above average are in the highest 1/3. Each model grid point is plotted with a matching color if the probability of bottom temperature being in one of these categories is 50% or more. If no category has a probability of at least 50%, the grid point is shaded gray for uncertain. The probabilities are determined using extended logistic regression, which uses historical forecasts and observations to calibrate the forecasts.
+
+The decadal prediction plot shows  annual bottom temperature anomalies averaged over the Northeast US shelf region. The anomalies are calculated from historical forecasts for years 1993--2022. The ensemble mean prediction is plotted as a line, and uncertainty is indicated by shading ±1 ensemble standard deviation. In addition to the most recent forecast, historical forecasts from previous years are shown to help visualize the forecast accuracy.
 
 ## Key Results and Visualizations
-Coming soon
+The  seasonal forecast from January 2026 predicts that cooler than average bottom temperatures will persist across much of the deeper Northeast US shelf, with near average conditions in some shallower regions. There is not a strong signal in the forecast for summer, but warmer than normal conditions are predicted to emerge in most shallow regions in the fall.
+
+The decadal forecast from January 2025 predicts a return to near average bottom temperatures over the next few years, with a fair amount of uncertainty. Past forecasts were able to accurately predict the rapid warming that begain in the mid-2000s and the recent cooling, raising confidence in the accuracy of the predictions.
 
 
 ## Indicator statistics 
-Spatial scale: Coming soon
+Spatial scale: The MOM6 ocean model runs at 1/12° horizontal resolution. For the seasonal forecasts, the data are shown at this resolution for the Northeast US shelf region. For the decadal forecasts, the data are averaged over the Northeast US shelf.
 
-Temporal scale: Coming soon
+Temporal scale: Seasonal averages (January-March, April-June, July-September, October-December) over the next year for seasonal forecasts. Annual averages over the next ten years for decadal forecasts.
 
 **Synthesis Theme**:
 
-
+- [x] Multiple System Drivers
 
 
 ```{r autostats_MOM6_forecasts}
@@ -37,29 +43,30 @@ Temporal scale: Coming soon
 ```
 
 ## Implications
-Coming soon
+These forecasts are from the first seasonal to decadal prediction system capable of resolving many of the important oceanographic features of the Northeast US shelf. Additional research is needed to determine whether predictable oceanographic changes on seasonal to decadal time scales can be linked to predictable ecosystem changes.
 
 ## Get the data
 
-**Point of contact**: [EDAB (edab.data@noaa.gov)](mailto:EDAB (edab.data@noaa.gov)){.email}
+**Point of contact**: [Andrew Ross (andrew.c.ross@noaa.gov)](mailto:Andrew Ross (andrew.c.ross@noaa.gov)){.email}
 
 **ecodata name**: No dataset
 
 **Variable definitions**
 
-Coming soon
+Name: tob_anom; Definition: Bottom temperature anomaly; Units: °C
 
 
 No Data
 
 **Indicator Category**:
 
-
+- [x] Published Methods
+- [x] Extensive analysis, not yet published
 
 
 ## Public Availability
 
-Source data are publicly available.
+Source data are publicly available from the [CEFI data portal](https://psl.noaa.gov/cefi_portal/).
 
 ## Accessibility and Constraints
 

--- a/chapters/SAV.rmd
+++ b/chapters/SAV.rmd
@@ -27,12 +27,6 @@ ggplotObject <- ecodata::plot_SAV(report = 'MidAtlantic', n = 10)
 ggplotObject
 ```
 
-```{r plot_SAVNewEngland}
-# Plot indicator
-ggplotObject <- ecodata::plot_SAV(report = 'NewEngland', n = 10)
-ggplotObject
-```
-
 
 ## Indicator statistics 
 Spatial scale: The data covers the tidal Chesapeake Bay region.
@@ -68,8 +62,10 @@ The outlook toward achieving the outcome goal is off course. Significant increas
 **Variable definitions**
 
 1) Name: Year; Definition: SAV growing season; year 2) Name: Tidal Fresh Total; Definition: SAV area in the Tidal Fresh Zone; Units: acres 
-3) Name: Oligohaline Total; Definition: SAV area in the Oligohaline Zone; Units: acres 4) Name: Mesohaline Total; Definition: SAV area in the Mesohaline Zone; Units: acres 
-5) Name: Polyhaline Total; Definition: SAV area in the Polyhaline Zone; Units: acres 6) Name: Baywide Total; Definition: Total SAV area in Chesapeake Bay; Units: acres
+3) Name: Oligohaline Total; Definition: SAV area in the Oligohaline Zone; Units: acres 
+4) Name: Mesohaline Total; Definition: SAV area in the Mesohaline Zone; Units: acres 
+5) Name: Polyhaline Total; Definition: SAV area in the Polyhaline Zone; Units: acres 
+6) Name: Baywide Total; Definition: Total SAV area in Chesapeake Bay; Units: acres
 
 ```{r vars_SAV}
 # Pull all var names

--- a/chapters/ch_bay_sal.rmd
+++ b/chapters/ch_bay_sal.rmd
@@ -27,12 +27,6 @@ ggplotObject <- ecodata::plot_ch_bay_sal(report = 'MidAtlantic')
 ggplotObject
 ```
 
-```{r plot_ch_bay_salNewEngland}
-# Plot indicator
-ggplotObject <- ecodata::plot_ch_bay_sal(report = 'NewEngland')
-ggplotObject
-```
-
 
 ## Indicator statistics 
 Spatial scale: Main stem of the Chesapeake Bay

--- a/chapters/ch_bay_temp.rmd
+++ b/chapters/ch_bay_temp.rmd
@@ -27,12 +27,6 @@ ggplotObject <- ecodata::plot_ch_bay_temp(report = 'MidAtlantic')
 ggplotObject
 ```
 
-```{r plot_ch_bay_tempNewEngland}
-# Plot indicator
-ggplotObject <- ecodata::plot_ch_bay_temp(report = 'NewEngland')
-ggplotObject
-```
-
 
 ## Indicator statistics 
 Spatial scale: Main stem of the Chesapeake Bay

--- a/chapters/ches_bay_wq.rmd
+++ b/chapters/ches_bay_wq.rmd
@@ -36,12 +36,6 @@ ggplotObject <- ecodata::plot_ches_bay_wq(report = 'MidAtlantic', n = 10)
 ggplotObject
 ```
 
-```{r plot_ches_bay_wqNewEngland}
-# Plot indicator
-ggplotObject <- ecodata::plot_ches_bay_wq(report = 'NewEngland', n = 10)
-ggplotObject
-```
-
 
 ## Indicator statistics 
 Spatial scale: Chesapeake Bay
@@ -70,11 +64,13 @@ Patterns of attainment are variable among designated uses. A Mann-Kendall trend 
 
 **Variable definitions**
 
-1. Period: Assessment period 2. Year One: Starting year of the assessment period 3. Year Two: Ending year of the assessment period 4. Total: The overall attainment indicator 
+1. Period: Assessment period 2. Year One: Starting year of the assessment period 3. Year Two: Ending year of the assessment period 
+4. Total: The overall attainment indicator 
 5. MSN-DO: Estimated attainment of the dissolved oxygen criterion for the migratory spawning and nursery designated use 
 6. OW-DO: Estimated attainment of the dissolved oxygen criterion for the open water designated use 
 7. DW-DO: Estimated attainment of the dissolved oxygen criterion for the deep water designated use 
-8. DC-DO: Estimated attainment of the dissolved oxygen criterion for the deep channel designated use 9. OW-CHLA: Estimated attainment of the chlorophyll-a criterion 
+8. DC-DO: Estimated attainment of the dissolved oxygen criterion for the deep channel designated use 
+9. OW-CHLA: Estimated attainment of the chlorophyll-a criterion 
 10. SW-Clarity/SAV: Estimated attainment of the bay grasses / water clarity criterion for the shallow water designated use
 
 ```{r vars_ches_bay_wq}

--- a/chapters/cold_pool.rmd
+++ b/chapters/cold_pool.rmd
@@ -29,33 +29,15 @@ ggplotObject <- ecodata::plot_cold_pool(report = 'MidAtlantic', varName = 'cold_
 ggplotObject
 ```
 
-```{r plot_cold_poolNewEnglandcold_pool}
-# Plot indicator
-ggplotObject <- ecodata::plot_cold_pool(report = 'NewEngland', varName = 'cold_pool', n = 10)
-ggplotObject
-```
-
 ```{r plot_cold_poolMidAtlanticpersistence}
 # Plot indicator
 ggplotObject <- ecodata::plot_cold_pool(report = 'MidAtlantic', varName = 'persistence', n = 10)
 ggplotObject
 ```
 
-```{r plot_cold_poolNewEnglandpersistence}
-# Plot indicator
-ggplotObject <- ecodata::plot_cold_pool(report = 'NewEngland', varName = 'persistence', n = 10)
-ggplotObject
-```
-
 ```{r plot_cold_poolMidAtlanticextent}
 # Plot indicator
 ggplotObject <- ecodata::plot_cold_pool(report = 'MidAtlantic', varName = 'extent', n = 10)
-ggplotObject
-```
-
-```{r plot_cold_poolNewEnglandextent}
-# Plot indicator
-ggplotObject <- ecodata::plot_cold_pool(report = 'NewEngland', varName = 'extent', n = 10)
 ggplotObject
 ```
 
@@ -88,8 +70,9 @@ Changes in the cold pool habitat can affect species distribution, recruitment, a
 **Variable definitions**
 
 1) Source: ROMS (bias-corrected ROMS-NWA bottom temperature [@dupontavice_ocean_2022]), GLORYS (CMEM’s GLORYS12V1 global reanalysis bottom temperature), PSY (CMEM’s PSY global forecast bottom temperature) 
-2) year 3) cold_pool_index: measure of mean temperature within cold pool 4) se_cold_pool_index: standard error of cold_pool_index 5) persistence_index: measure of duration of cold pool 
-6) se_persistence_index: standard error of persistence_index 7) extent_index: measure of spatial extent of cold pool 8) se_extent_index: standard error of extent_index
+2) year 3) cold_pool_index: measure of mean temperature within cold pool 4) se_cold_pool_index: standard error of cold_pool_index 
+5) persistence_index: measure of duration of cold pool 6) se_persistence_index: standard error of persistence_index 
+7) extent_index: measure of spatial extent of cold pool 8) se_extent_index: standard error of extent_index
 
 ```{r vars_cold_pool}
 # Pull all var names

--- a/chapters/gom_acidification.rmd
+++ b/chapters/gom_acidification.rmd
@@ -19,9 +19,9 @@ library(ecodata)
 The pCO2 represents the partial pressure of carbon dioxide resulting from the combination of water mass mixing, air-sea exchange, and biogeochemical processes.  Omega-a represents the saturation of calcium carbonate, an important mineral for many shell-building marine species and commonly-sed indicator of ocean acidification condition.
 
 ## Key Results and Visualizations
-![Figure 1](https://github.com/NOAA-EDAB/ecodata/raw/pre-production/data-raw/workshop/images/SOE_2026_gom_acidification_pCO2.png){width=100%}
+![](https://github.com/NOAA-EDAB/ecodata/raw/pre-production/data-raw/workshop/images/SOE_2026_gom_acidification_pCO2.png){width=100%}
 
-![Figure 2](https://github.com/NOAA-EDAB/ecodata/raw/pre-production/data-raw/workshop/images/SOE_2026_gom_acidification_omega.png){width=100%}
+![](https://github.com/NOAA-EDAB/ecodata/raw/pre-production/data-raw/workshop/images/SOE_2026_gom_acidification_omega.png){width=100%}
 
 In 2025, pCO2 followed the general pattern of elevated levels in the fall and winter and reduced levels in the spring and early summer. A data gap is present when the buoy was removed for service.  Omega-a reflected the pCO2, with lower levels in the fall and winter and elevated levels in spring and early summer. This pattern is generally due to a combination of seasonal temperature shifts and the cyclical spring phytoplankton bloom. However, the levels of pCO2 at the beginning and end of 2025 were generally above the climatological mean, and Omega-a was similarly low. This pattern was also seen in 2024; however, the salinity in 2025 was not abnormally low as in 2024. This may indicate that other factors are contributing to the higher pCO2 and lower Omega-a in the early and late stages of both years.
 
@@ -52,7 +52,8 @@ Ocean acidification conditions were pronounced for extended periods early and la
 
 **Variable definitions**
 
-1) pCO2; Definition: partial pressure of carbon dioxide; Units: microatmospheres 2)Omega-a; Definition: Saturation state of calcium carbonate as aragonite; Units: unitless
+1) pCO2; Definition: partial pressure of carbon dioxide; Units: microatmospheres 
+2)Omega-a; Definition: Saturation state of calcium carbonate as aragonite; Units: unitless
 
 
 No Data

--- a/chapters/gom_salmon.rmd
+++ b/chapters/gom_salmon.rmd
@@ -27,12 +27,6 @@ ggplotObject <- ecodata::plot_gom_salmon(report = 'MidAtlantic', n = 10)
 ggplotObject
 ```
 
-```{r plot_gom_salmonNewEngland}
-# Plot indicator
-ggplotObject <- ecodata::plot_gom_salmon(report = 'NewEngland', n = 10)
-ggplotObject
-```
-
 
 ## Indicator statistics 
 Spatial scale: EPU = Gulf of Maine

--- a/chapters/grayseal.rmd
+++ b/chapters/grayseal.rmd
@@ -27,12 +27,6 @@ ggplotObject <- ecodata::plot_grayseal(report = 'MidAtlantic')
 ggplotObject
 ```
 
-```{r plot_graysealNewEngland}
-# Plot indicator
-ggplotObject <- ecodata::plot_grayseal(report = 'NewEngland')
-ggplotObject
-```
-
 
 ## Indicator statistics 
 Spatial scale: Spatial scale: U.S. waters from North Carolina to Canada from the U.S. coastline to the U.S. exclusive economic zone 200 nautical miles offshore, thus including all EPUs, the full shelf and beyond.
@@ -59,8 +53,10 @@ Under the MMPA, if bycatch exceeds PBR levels, Take Reduction Teams may be conve
 
 **Variable definitions**
 
-1) pbr = Potential Biological Removal level. Unit = n (number of animals) 2) totalest1y = Total bycatch of 1 year annual estimate. Unit = n (number of animals) 
-3) totalest5y = Total bycatch of 5 year running average estimate. Unit = n (number of animals) 4) total5yLCI = Lower 95% confidence interval of totalest5y. Unit = n (number of animals) 
+1) pbr = Potential Biological Removal level. Unit = n (number of animals) 
+2) totalest1y = Total bycatch of 1 year annual estimate. Unit = n (number of animals) 
+3) totalest5y = Total bycatch of 5 year running average estimate. Unit = n (number of animals) 
+4) total5yLCI = Lower 95% confidence interval of totalest5y. Unit = n (number of animals) 
 5) total5yUCI= Upper 95% confidence interval of totalest5y. Unit = n (number of animals)
 
 ```{r vars_grayseal}

--- a/chapters/long_term_sst.rmd
+++ b/chapters/long_term_sst.rmd
@@ -27,12 +27,6 @@ ggplotObject <- ecodata::plot_long_term_sst(report = 'MidAtlantic', n = 10)
 ggplotObject
 ```
 
-```{r plot_long_term_sstNewEngland}
-# Plot indicator
-ggplotObject <- ecodata::plot_long_term_sst(report = 'NewEngland', n = 10)
-ggplotObject
-```
-
 
 ## Indicator statistics 
 Spatial scale: Full shelf

--- a/chapters/seal_pups.rmd
+++ b/chapters/seal_pups.rmd
@@ -28,12 +28,6 @@ ggplotObject <- ecodata::plot_seal_pups(report = 'MidAtlantic')
 ggplotObject
 ```
 
-```{r plot_seal_pupsNewEngland}
-# Plot indicator
-ggplotObject <- ecodata::plot_seal_pups(report = 'NewEngland')
-ggplotObject
-```
-
 
 ## Indicator statistics 
 Spatial scale: Haul out sites off New England (Maine to New York) that correspond roughly to EPU’s Gulf of Maine (GOM) and Mid-Atlantic Bight (MAB).

--- a/chapters/thermal_habitat_area.rmd
+++ b/chapters/thermal_habitat_area.rmd
@@ -1,6 +1,6 @@
 # Thermal Habitat Area {#thermal_habitat_area}
 
-**Description**: Calculates the proportion of each EPU that exceeds temperature thresholds as a daily time series from 1993 – 2024
+**Description**: Calculates the proportion of each EPU that exceeds temperature thresholds as a daily time series from 1993 – 2025
 
 **Indicator family**: 
 
@@ -17,10 +17,10 @@ knitr::opts_chunk$set(echo = F)
 library(ecodata)
 ```
 ## Introduction to Indicator
-See "Thermal Habitat Persistence" for cell-based calculations. Many deep water benthic and demersal species exhibit thermal preferences for metabolic, reproductive, and growth processes. Temperatures above these thermal preferences may impair these processes. Two temperature thresholds (15 and 24 degrees C) were chosen based on cutoff points where demersal species are less commonly found. Thermal habitat area is calculated by identifying 1/12 degree cells within a given EPU that are greater than or equal to the temperature threshold then taking the sum of all cell areas. Data from 1993-01-01 to 2024-09-10 were obtained from the CMEMS' GLORYS12V1 global reanalysis product.
+See "Thermal Habitat Gridded" for cell-based calculations. Many deep water benthic and demersal species exhibit thermal preferences for metabolic, reproductive, and growth processes. Temperatures above these thermal preferences may impair these processes. This analysis assesses the thermal habitat available within a region and depth range from 0.5 to 30 °C at 0.5 °C increments. Thermal habitat area is calculated by identifying 1/12 degree cells within a given EPU that are greater than or equal to the temperature threshold then taking the sum of all cell areas. Data from 1993-01-01 to 2025-12-31 were obtained from the CMEMS' GLORYS12V1 global reanalysis product. This indicator was expanded from a working paper for the [2025 Atlantic Sea Scallop Research Track](https://apps-nefsc.fisheries.noaa.gov/saw/sasi_files.php?year=2025&species_id=26&stock_id=6&review_type_id=5&info_type_id=5&map_type_id=&filename=2025_SCA_RT_WP_TOR1b%20Climate%20Influences.pdf). This indicator is also available as annual means using the same methods under `ecodata::thermal_habitat_area_annual`.
 
 ## Key Results and Visualizations
-For each EPU, bottom temperature data were separated by depth bin (0-25m; 25m-100m; and >100m), as well as temperature threshold (>15C , >24C), and the proportion of each EPU exceeding these thresholds was calculated on a daily basis from 1993 to 2024. Time series of each year's proportional area show an increasing proportion of the MAB and GB mid-depths have experienced high temperatures in recent years. The 24C threshold is rarely seen in GB and GOM.
+For each EPU, bottom temperature data were separated by depth bin (0-25m; 25m-100m; and \>100m), as well as temperature threshold (0.5-30 °C), and the proportion of each EPU exceeding these thresholds was calculated on a daily basis from 1993 to 2025. Each year in the time series is plotted as a separate line showing the suitable thermal habitat profile for that year. The current year is highlighted in black. Generally the MAB is warmer, so these curves are shifted to the right compared to GB and the GOM. The unusually cold conditions in 2024 and 2025 are shown by leftward shifts in temperature profiles compared to previous years. However, since 2024, the profiles for shallow areas show a flattening in the mid temperature ranges, indicating that a larger area was warmer than normal and potentially unsuitable for some species.
 
 ```{r plot_thermal_habitat_areaMABMidAtlantic}
 # Plot indicator
@@ -56,7 +56,7 @@ Temporal scale: daily
 ```
 
 ## Implications
-If a large proportion of species current habitat become thermally inhospitable, it can influence species' productivity and in, extreme cases, cause mortality.
+If a large proportion of species current habitat become thermally inhospitable, it can influence species' productivity and in, extreme cases, cause mortality. Monitoring the shape of these thermal suitability profiles can help identify areas that could influence temperature-sensitive species.
 
 ## Get the data
 
@@ -66,8 +66,8 @@ If a large proportion of species current habitat become thermally inhospitable, 
 
 **Variable definitions**
 
-Time: Date EPU: EPU name Depth: Depth category Var: Temperature Category Value: Proportion of area above temp.threshold 
-Source: GLORYS (CMEM’s GLORYS12V1 global reanalysis bottom temperature)  year: year Units: Proportion
+Time: year EPU: EPU name  Depth: Depth category  Var: Temperature Category  Value: Proportion of area above temp.threshold  
+Source: GLORYS (CMEM’s GLORYS12V1 global reanalysis bottom temperature)  temp.threshold: numeric temperature category  Units: Proportion
 
 ```{r vars_thermal_habitat_area}
 # Pull all var names

--- a/chapters/thermal_habitat_gridded.rmd
+++ b/chapters/thermal_habitat_gridded.rmd
@@ -1,4 +1,4 @@
-# Thermal Habitat Persistence {#thermal_habitat_gridded}
+# Thermal Habitat Gridded {#thermal_habitat_gridded}
 
 **Description**: The number of days per year per 1/12 degree cell that exceeds a temperature threshold.
 
@@ -17,10 +17,10 @@ knitr::opts_chunk$set(echo = F)
 library(ecodata)
 ```
 ## Introduction to Indicator
-Many deep water benthic and demersal species exhibit thermal preferences for metabolic, reproductive, and growth processes. Temperatures above these thermal presences may impair these processes. Data originate from GLORYS12V1 global reanalysis for 1993-01-01 to 2023-08-29, and from PSY forecasts from 2021-01-01 to 2023-12-31. Cells are mapped to 3 depth bins: 0-25m, 25-100m, and >100m. Two temperature thresholds are used, representing a temperature where moderate (15C) and extreme (24C) thermal stresses are likely to occur across several species. GLORYS and PSY 1/12 degree grid is mapped to EPU_NOESTUARIES shape files by the center point of each grid cell.
+Many deep water benthic and demersal species exhibit thermal preferences for metabolic, reproductive, and growth processes. Temperatures above these thermal presences may impair these processes. Data originate from GLORYS12V1 global reanalysis for 1993-01-01 to 2025-12-31. Cells are mapped to 3 depth bins: 0-25m, 25-100m, and >100m. Temperature thresholds range from 0.5 to 30 °C at 0.5 °C increments. The GLORYS 1/12 degree grid is mapped to EPU_NOESTUARIES shape files by the center point of each grid cell.
 
 ## Key Results and Visualizations
-Maps of full NE shelf with cell shading gradient showing number of days exceeding temperature thresholds. For 15C threshold, much of the southern Mid-Atlantic Bight (MAB), the shelf break and Nantucket Shoals experienced >100 days. In 2023, only the southern and/or shallow portion of the MAB exceeded the 24C threshold.
+Maps of full NE shelf with cell shading gradient showing number of days exceeding temperature thresholds. Thresholds at 15C and 24C are shown as they correspond to generalized tolerances for warm and cold water species. In 2025, much of the Mid-Atlantic Bight (MAB), the shelf break and Nantucket Shoals experienced some days exceeding 15C, with a longer duration in the southern MAB. In 2025, only the southern and/or shallow portion of the MAB exceeded the 24C threshold.
 
 ```{r plot_thermal_habitat_griddedMidAtlantic}
 # Plot indicator
@@ -50,7 +50,7 @@ Temporal scale: annual
 ```
 
 ## Implications
-Using a high resolution bottom temperature product elucidates localized heat stress within EPUs that may be masked when looking at mean EPU bottom temperature. This can be important to sessile species who aren't able to move out of warm water conditions.
+Using a high resolution bottom temperature product shows localized heat stress within EPUs that may be masked when looking at mean EPU bottom temperature. It is important to look at the spatial patterns of temperature exceedances to understand the potential impacts on species with different thermal tolerances and habitat preferences. The duration of such events is also important in determining potential mortality risk.
 
 ## Get the data
 
@@ -60,9 +60,9 @@ Using a high resolution bottom temperature product elucidates localized heat str
 
 **Variable definitions**
 
-Source: GLORYS (CMEM’s GLORYS12V1 global reanalysis bottom temperature) and PSY (CMEM’s PSY global forecast bottom temperature) min.depth: minimum of depth band 
-max.depth: maximum of depth band temp.threshold: cutoff temperature for thermal area calculations (all areas greater than or equal to this temperature) 
-longitude: longitude of cell center point latitude: latitude of cell center point Ndays: number of days exceeding temp.threshold
+Time: year EPU: EPU Depth: Depth Category Var: cutoff temperature for thermal area calculations (all areas greater than or equal to this temperature)  
+Value: Number of days exceeding Var Latitude: latitude of cell center point Longitude: longitude of cell center point 
+Source: GLORYS (CMEM’s GLORYS12V1 global reanalysis bottom temperature) Units: Number of Days
 
 ```{r vars_thermal_habitat_gridded}
 # Pull all var names


### PR DESCRIPTION
### Justification
Several plot functions were adjusted to prevent the creation of duplicate plots. Most of the pages changed here were rebuilt using the corrected plot functions. There were substantive additions made to the MOM6 Forecasts, Thermal Habitat Area and Thermal Habitat Persistence pages, which headline this PR. All of these changes were recommended by reviewers or requested by page authors. These changes resolve #215.

### Types of changes
What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [x] Feature (non-breaking change which adds or changes functionality)

### Further comments
Please note that we _will not_ increment the _Catalog_ version despite this being a feature change. We will implement proper Semantic Versioning after the next release.

### Review instructions:
Please test by:
1) Building/loading _ecodata_ from the `pre-production` branch
2) Rendering catalog from the `feature/i215-redeploy-revised-pages` branch using: `bookdown::render_book()`*
3) Reviewing the book (found in "_book\index.html") for issues
4) Reviewing changed files for issues

*I strongly recommend changing all instances of `n = 10` to `n = 0`. Rendering the book with short term trends disabled saves considerable time.